### PR TITLE
Support token replacement in config files.

### DIFF
--- a/lib/atomic-management.js
+++ b/lib/atomic-management.js
@@ -212,7 +212,17 @@ export default {
       if (contents === undefined) {
         contents = {};
       } else {
-        contents = JSON.parse(JSON.stringify(contents));
+        const tokens = {
+          "PROJECT_PATH": path.dirname(path.dirname(configName))
+        };
+
+        let json_string = JSON.stringify(contents);
+        for (let key in tokens) {
+          const regex = new RegExp(`\\$\{${key}}`, "g");
+          json_string = json_string.replace(regex, tokens[key]);
+        }
+
+        contents = JSON.parse(json_string);
       }
 
       contents = this.standardizeConfig(contents);


### PR DESCRIPTION
Support token replacement in config files.
The only token currently supported is `${PROJECT_PATH}`.
This allows tools like linter-yaml to get yamllint from a project specific python virtualenv.

**Project Config**
![image](https://user-images.githubusercontent.com/1904898/102914453-22a31280-4435-11eb-850e-f26feef03a1d.png)

**Result Config**
![image](https://user-images.githubusercontent.com/1904898/102914671-8299b900-4435-11eb-8f11-ac8ce5b08db4.png)
